### PR TITLE
Added a max width to parent element of both filter components

### DIFF
--- a/src/components/AllPosts.jsx
+++ b/src/components/AllPosts.jsx
@@ -49,7 +49,7 @@ import { FormControl, Grid, InputAdornment, InputLabel, MenuItem, Select, TextFi
                 flexDirection={"column"}
                 alignItems={"center"}
             >
-                <Grid container direction={"row"} justifyContent={"space-between"} width={0.7} margin={2}>
+                <Grid container direction={"row"} justifyContent={"space-between"} width={0.7} maxWidth={800} margin={2}>
                     <Box>
                         <FormControl sx={{width: 200}}>
                             <InputLabel>Filter by Topic</InputLabel>


### PR DESCRIPTION
### Purpose
Prevent the filter inputs from expanding horizontally beyond the border of the cards

### Files Changed
- Added a max width to parent element of both filter components in `AllPosts.jsx`

### To Test
Fetch, host JSON server, and run "npm run dev"
- Confirm that the filters stay properly aligned at many different browser window widths