### PR TITLE
Fixed like counter including postLikes where isLiked equals false

### DIFF
--- a/src/components/posts/Post.jsx
+++ b/src/components/posts/Post.jsx
@@ -27,7 +27,7 @@ export const Post = ({ post }) => {
                 fontWeight: "bold",
                 color: "#6F6F6F"
             }}>
-                {post.postLikes.length} Likes
+                {post.postLikes.filter(like => like.isLiked === true).length} Likes
             </Typography>
         </Paper>
     )


### PR DESCRIPTION
### Purpose
To fix the likes counter for posts in the All Posts view

### Files Changed
- Added filter for like counter to only include likes where isLiked is true in `Post.jsx`

### To Test
Fetch, host related `learning-api` json server, and run "npm run dev"
- Confirm like counters in All Posts view are correct